### PR TITLE
Rename and reorganize folder structure and project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Spring Boot Hello World
-This project is an introductory project for building an understanding of the Spring Boot framework as well as setting up simple REST APIs with microservice architecture.
+# Accounts API
+A microservice application for managing account information for a bank.

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,11 @@
 		<version>3.3.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.example.springboothelloworld</groupId>
-	<artifactId>springboothelloworld</artifactId>
+	<groupId>com.hellobank</groupId>
+	<artifactId>accounts-api</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>springboothelloworld</name>
-	<description>Demo project for Spring Boot</description>
+	<name>accounts-api</name>
+	<description>A microservice application for managing account information for a bank.</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -68,12 +68,6 @@
 						</goals>
 					</execution>
 				</executions>
-				<configuration>
-					<excludes>
-						<exclude>com/example/springboothelloworld/domain*</exclude>
-						<exclude>com/example/springboothelloworld/controller/domain*</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/hellobank/AccountsAPI.java
+++ b/src/main/java/com/hellobank/AccountsAPI.java
@@ -1,14 +1,14 @@
-package com.example.springboothelloworld;
+package com.hellobank;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class SpringBootHelloWorldApplication {
+public class AccountsAPI {
 
 	public static void main(String[] args) {
 
-		SpringApplication.run(SpringBootHelloWorldApplication.class, args);
+		SpringApplication.run(AccountsAPI.class, args);
 
 	}
 

--- a/src/main/java/com/hellobank/account/controller/AccountController.java
+++ b/src/main/java/com/hellobank/account/controller/AccountController.java
@@ -1,10 +1,10 @@
-package com.example.springboothelloworld.account.controller;
+package com.hellobank.account.controller;
 
-import com.example.springboothelloworld.account.controller.domain.AccountControllerErrorResponse;
-import com.example.springboothelloworld.account.controller.domain.AccountControllerResponse;
-import com.example.springboothelloworld.account.controller.domain.AccountControllerSuccessfulResponse;
-import com.example.springboothelloworld.account.domain.Account;
-import com.example.springboothelloworld.account.service.AccountManagerService;
+import com.hellobank.account.controller.domain.AccountControllerErrorResponse;
+import com.hellobank.account.controller.domain.AccountControllerResponse;
+import com.hellobank.account.controller.domain.AccountControllerSuccessfulResponse;
+import com.hellobank.account.domain.Account;
+import com.hellobank.account.service.AccountManagerService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/hellobank/account/controller/domain/AccountControllerErrorResponse.java
+++ b/src/main/java/com/hellobank/account/controller/domain/AccountControllerErrorResponse.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.account.controller.domain;
+package com.hellobank.account.controller.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/main/java/com/hellobank/account/controller/domain/AccountControllerResponse.java
+++ b/src/main/java/com/hellobank/account/controller/domain/AccountControllerResponse.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.account.controller.domain;
+package com.hellobank.account.controller.domain;
 
 public interface AccountControllerResponse {
     // Used for abstracting generalizing REST API responses.

--- a/src/main/java/com/hellobank/account/controller/domain/AccountControllerSuccessfulResponse.java
+++ b/src/main/java/com/hellobank/account/controller/domain/AccountControllerSuccessfulResponse.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.account.controller.domain;
+package com.hellobank.account.controller.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/main/java/com/hellobank/account/domain/Account.java
+++ b/src/main/java/com/hellobank/account/domain/Account.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.account.domain;
+package com.hellobank.account.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/hellobank/account/repository/AccountRepository.java
+++ b/src/main/java/com/hellobank/account/repository/AccountRepository.java
@@ -1,6 +1,6 @@
-package com.example.springboothelloworld.account.repository;
+package com.hellobank.account.repository;
 
-import com.example.springboothelloworld.account.domain.Account;
+import com.hellobank.account.domain.Account;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 @Repository
 public class AccountRepository {
-    private static final ArrayList<Account> accounts = new ArrayList<Account>();
+    private static final ArrayList<Account> accounts = new ArrayList<>();
 
     public Account insertAccount(Account account) {
         accounts.add(account);

--- a/src/main/java/com/hellobank/account/service/AccountManagerService.java
+++ b/src/main/java/com/hellobank/account/service/AccountManagerService.java
@@ -1,9 +1,9 @@
-package com.example.springboothelloworld.account.service;
+package com.hellobank.account.service;
 
-import com.example.springboothelloworld.account.domain.Account;
-import com.example.springboothelloworld.account.repository.AccountRepository;
+import com.hellobank.account.domain.Account;
+import com.hellobank.account.repository.AccountRepository;
 import org.springframework.stereotype.Service;
-import java.util.ArrayList;
+
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/hellobank/config/JacksonConfig.java
+++ b/src/main/java/com/hellobank/config/JacksonConfig.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.config;
+package com.hellobank.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/src/test/java/com/hellobank/AccountsAPITests.java
+++ b/src/test/java/com/hellobank/AccountsAPITests.java
@@ -1,13 +1,14 @@
-package com.example.springboothelloworld;
+package com.hellobank;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class SpringboothelloworldApplicationTests {
+class AccountsAPITests {
 
 	@Test
 	void contextLoads() {
+		AccountsAPI.main(new String[] {});
 	}
 
 }

--- a/src/test/java/com/hellobank/account/repository/AccountRepositoryTest.java
+++ b/src/test/java/com/hellobank/account/repository/AccountRepositoryTest.java
@@ -1,13 +1,11 @@
-package com.example.springboothelloworld.unit.account.repository;
+package com.hellobank.account.repository;
 
-import com.example.springboothelloworld.account.domain.Account;
-import com.example.springboothelloworld.account.repository.AccountRepository;
+import com.hellobank.account.domain.Account;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/test/java/com/hellobank/account/service/AccountManagerServiceTest.java
+++ b/src/test/java/com/hellobank/account/service/AccountManagerServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.springboothelloworld.unit.account.service;
+package com.hellobank.account.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,9 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.example.springboothelloworld.account.domain.Account;
-import com.example.springboothelloworld.account.repository.AccountRepository;
-import com.example.springboothelloworld.account.service.AccountManagerService;
+import com.hellobank.account.domain.Account;
+import com.hellobank.account.repository.AccountRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
Closes #8

* Rename project from `springboothelloworld` to `accounts-api`
    * Make sure the maven config files are updated to match the name changes for the application references.
* Rename `com.example.springboothelloworld.account` to `com.hellobank.account`
* Reorganize the test file structure from:
```
com.example.springboothelloworld
| unit.account
| - | repository
| - | service
```
to
```
com.hellobank.account
| repository
| service
```